### PR TITLE
fix(workflows): remove github actions default workflow git setup

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -23,14 +23,6 @@ jobs:
     steps:
       - name: checkout
         uses: 'actions/checkout@v1'
-      - name: git setup
-        env:
-          GITHUB_SSHKEY: '${{ secrets.GITHUB_SSHKEY }}'
-        run: |
-          mkdir -p "$HOME/.ssh" ; chmod 700 "$HOME/.ssh" ;
-          ssh-keyscan -H "github.com" >> "$HOME/.ssh/known_hosts" ;
-          echo "$GITHUB_SSHKEY" | base64 --decode > "$HOME/.ssh/id_rsa" ;
-          chmod 600 $HOME/.ssh/* ;
       - name: npm install
         env:
           NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}'


### PR DESCRIPTION
# What / Why
<!-- Describe the request in detail -->
> Remove github actions default workflow git setup, this was a stub for npm packages being read from git and no longer necessary

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* n/a
