### PR TITLE
Remove "default" from branch protection contexts

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -30,7 +30,6 @@ branches:
           users: []
       required_status_checks:
         strict: true
-        contexts: ['default']
       restrictions:
         teams: []
         users: []


### PR DESCRIPTION
This ends up being nonsense to the repos inheriting this, blocking the PR with a check that can never pass.