### PR TITLE
fix: update settings.yml to stop dropping admin privileges

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -40,7 +40,7 @@ teams:
   - { name: 'robot-write',  permission: 'admin' }
   - { name: 'robot',        permission: 'pull'  }
   - { name: 'employees',    permission: 'pull'  }
-  - { name: 'eng',          permission: 'push'  }
+  - { name: 'eng',          permission: 'admin'  }
 
 labels:
 


### PR DESCRIPTION
# What / Why
<!-- Describe the request in detail -->
This keeps stepping on making the eng team an admin

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* n/a
