### PR TITLE
fix: drop the enforce_admins setting so admins can override merges

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -20,7 +20,7 @@ repository:
 branches:
   - name: master
     protection:
-      enforce_admins: true
+      enforce_admins: false
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         require_code_owner_reviews: true


### PR DESCRIPTION
# What / Why
<!-- Describe the request in detail -->
> This setting goes completely against what we declared our intended usage to be

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* n/a
