### PR TITLE
fix: set-env is deprecated

### DIFF
--- a/workflow-templates/deploy.yaml
+++ b/workflow-templates/deploy.yaml
@@ -13,12 +13,12 @@ jobs:
     
     - name: Set staging variables
       run: |
-        echo "::set-env name=ENVIRONMENT_URL::https://your_service.npm.red"
+        echo "ENVIRONMENT_URL=https://your_service.npm.red" >> $GITHUB_ENV
       if: github.ref == 'refs/heads/deploy-staging'
 
     - name: Set production variables
       run: |
-        echo "::set-env name=ENVIRONMENT_URL::https://your_service.internal.npmjs.com"
+        echo "ENVIRONMENT_URL=https://your_service.internal.npmjs.com" >> $GITHUB_ENV
       if: github.ref == 'refs/heads/deploy-production'
 
     - name: create a deployment


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
