### PR TITLE
Add starter workflow for building and publishing a Docker image

### DIFF
--- a/workflow-templates/build-container.properties.json
+++ b/workflow-templates/build-container.properties.json
@@ -1,0 +1,5 @@
+{
+  "name": "Publish Docker image",
+  "description": "Publishes Docker image to your org's GitHub's Container Registry",
+  "filePatterns": ["^Dockerfile"]
+}

--- a/workflow-templates/build-container.yaml
+++ b/workflow-templates/build-container.yaml
@@ -1,0 +1,43 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: [ $default-branch ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GH_PACKAGES_TOKEN=${{ secrets.GH_PACKAGES_READWRITE}}


### PR DESCRIPTION
This allows us to have a common workflow made available to all
npm services who want to publish their containers to GHCR

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
